### PR TITLE
Return impl iterator from permutate methods

### DIFF
--- a/twistrs/Cargo.toml
+++ b/twistrs/Cargo.toml
@@ -30,6 +30,7 @@ fancy-regex = "0.4.0"
 idna = "0.2.0"
 hyper = "0.13.8"
 maxminddb = { version = "0.15.0", optional = true}
+itertools = "0.9.0"
 
 [build-dependencies]
 punycode = "0.4.1"

--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -27,7 +27,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let domain = Domain::new("google.com").unwrap();
-//!     let permutations = domain.addition().unwrap();
+//!     let permutations = domain.addition();
 //!
 //!     let (tx, mut rx) = mpsc::channel(1000);
 //!

--- a/twistrs/src/permutate.rs
+++ b/twistrs/src/permutate.rs
@@ -12,7 +12,7 @@
 //! use twistrs::permutate::Domain;
 //!
 //! let domain = Domain::new("google.com").unwrap();
-//! let domain_permutations = domain.all().unwrap().collect::<Vec<String>>();
+//! let domain_permutations: Vec<String> = domain.all().collect();
 //! ```
 //!
 //! Additionally the permutation module can be used independently
@@ -25,6 +25,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use idna::punycode;
+use itertools::Itertools;
 
 // Include further constants such as dictionaries that are
 // generated during compile time.
@@ -80,7 +81,7 @@ impl<'a> Domain<'a> {
                     return Err(PermutationError);
                 }
 
-                let tld = format!("{}", String::from(parts[len - 1]));
+                let tld = parts[len - 1].to_string();
                 let domain = String::from(parts[len - 2]);
 
                 Ok(Domain { fqdn, tld, domain })
@@ -97,36 +98,30 @@ impl<'a> Domain<'a> {
     ///
     /// Any future permutations will also be included into this function call
     /// without any changes required from any client implementations.
-    pub fn all(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let permutations = self
-            .addition()
-            .and_then(|i| Ok(i.chain(self.bitsquatting()?)))
-            .and_then(|i| Ok(i.chain(self.homoglyph()?)))
-            .and_then(|i| Ok(i.chain(self.hyphentation()?)))
-            .and_then(|i| Ok(i.chain(self.insertion()?)))
-            .and_then(|i| Ok(i.chain(self.omission()?)))
-            .and_then(|i| Ok(i.chain(self.repetition()?)))
-            .and_then(|i| Ok(i.chain(self.replacement()?)))
-            .and_then(|i| Ok(i.chain(self.subdomain()?)))
-            .and_then(|i| Ok(i.chain(self.transposition()?)))
-            .and_then(|i| Ok(i.chain(self.vowel_swap()?)))
-            .and_then(|i| Ok(i.chain(self.keyword()?)))
-            .and_then(|i| Ok(i.chain(self.tld()?)))?;
-
-        Ok(Box::new(permutations))
+    pub fn all(&self) -> impl Iterator<Item = String> + '_ {
+        self.addition()
+            .chain(self.bitsquatting())
+            .chain(self.hyphentation())
+            .chain(self.insertion())
+            .chain(self.omission())
+            .chain(self.repetition())
+            .chain(self.replacement())
+            .chain(self.subdomain())
+            .chain(self.transposition())
+            .chain(self.vowel_swap())
+            .chain(self.keyword())
+            .chain(self.tld())
+            .chain(self.homoglyph())
     }
 
     /// Add every ASCII lowercase character between the Domain
     /// (e.g. `google`) and top-level domain (e.g. `.com`).
-    pub fn addition(&self) -> Result<impl Iterator<Item = String> + '_> {
-        let mut result: Vec<String> = vec![];
-        for c in ASCII_LOWER.iter() {
-            result.push(format!("{}{}.{}", self.domain, c.to_string(), self.tld));
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn addition(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(
+            ASCII_LOWER
+                .iter()
+                .map(move |c| format!("{}{}.{}", self.domain, c.to_string(), self.tld)),
+        )
     }
 
     /// Following implementation takes inspiration from the following content:
@@ -146,39 +141,40 @@ impl<'a> Domain<'a> {
     ///  10000000 ^ chr
     ///
     /// Then check if the resulting bit operation falls within ASCII range.
-    pub fn bitsquatting(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-        let fqdn = self.fqdn.to_string();
+    pub fn bitsquatting(&self) -> impl Iterator<Item = String> + '_ {
+        let permutations = self
+            .fqdn
+            .chars()
+            .flat_map(move |c| {
+                (0..8).filter_map(move |mask_index| {
+                    let mask = 1 << mask_index;
 
-        for c in fqdn.chars().collect::<Vec<char>>().iter() {
-            for mask_index in 0..8 {
-                let mask = 1 << mask_index;
+                    // Can the below panic? Should we use a wider range (u32)?
+                    let squatted_char: u8 = mask ^ (c as u8);
 
-                // Can the below panic? Should we use a wider range (u32)?
-                let squatted_char: u8 = mask ^ (*c as u8);
-
-                // Make sure we remain with ASCII range that we are happy with
-                if (squatted_char >= 48 && squatted_char <= 57)
-                    || (squatted_char >= 97 && squatted_char <= 122)
-                    || squatted_char == 45
-                {
-                    for idx in 1..fqdn.len() {
-                        let mut permutation = self.fqdn.to_string();
-                        permutation.insert(idx, squatted_char as char);
-                        result.push(permutation);
+                    // Make sure we remain with ASCII range that we are happy with
+                    if (squatted_char >= 48 && squatted_char <= 57)
+                        || (squatted_char >= 97 && squatted_char <= 122)
+                        || squatted_char == 45
+                    {
+                        Some((1..self.fqdn.len()).map(move |idx| {
+                            let mut permutation = self.fqdn.to_string();
+                            permutation.insert(idx, squatted_char as char);
+                            permutation
+                        }))
+                    } else {
+                        None
                     }
-                }
-            }
-        }
+                })
+            })
+            .flatten();
 
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+        Domain::filter_domains(permutations)
     }
 
     /// Permutation method that replaces ASCII characters with multiple homoglyphs
     /// similar to the respective ASCII character.
-    pub fn homoglyph(&self) -> Result<Box<dyn Iterator<Item = String>>> {
+    pub fn homoglyph(&self) -> impl Iterator<Item = String> + '_ {
         // @CLEANUP(jdb): Tidy this entire mess up
         let mut result_first_pass: HashSet<String> = HashSet::new();
         let mut result_second_pass: HashSet<String> = HashSet::new();
@@ -250,222 +246,158 @@ impl<'a> Domain<'a> {
             }
         }
 
-        dbg!(&result_first_pass);
-        dbg!(&result_second_pass);
-
-        Domain::filter_domains(Box::new(
-            (&result_first_pass | &result_second_pass)
-                .into_iter()
-                .collect::<Vec<String>>()
-                .into_iter(),
-        ))
+        Domain::filter_domains((&result_first_pass | &result_second_pass).into_iter())
     }
 
     /// Permutation method that inserts hyphens (i.e. `-`) between each
     /// character in the domain where valid.
-    pub fn hyphentation(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-        let fqdn = self.fqdn.to_string();
-
-        for (i, _) in fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            // Skip the first index, as domains cannot start with hyphen
-            if i == 0 {
-                continue;
-            }
-
+    pub fn hyphentation(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(self.fqdn.chars().skip(1).enumerate().map(move |(i, _)| {
             let mut permutation = self.fqdn.to_string();
             permutation.insert(i, '-');
-            result.push(permutation);
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+            permutation
+        }))
     }
 
     /// Permutation method that inserts specific characters that are close to
     /// any character in the domain depending on the keyboard (e.g. `Q` next
     /// to `W` in qwerty keyboard layout.
-    pub fn insertion(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-        let fqdn = self.fqdn.to_string();
-
-        for (i, c) in fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            // We do not want to insert in the beginning or in the end of the domain
-            if i == 0 || i == fqdn.len() - 1 {
-                continue;
-            }
-
-            for keyboard_layout in KEYBOARD_LAYOUTS.iter() {
-                if keyboard_layout.contains_key(c) {
-                    for keyboard_char in keyboard_layout
-                        .get(c)
-                        .unwrap()
-                        .chars()
-                        .collect::<Vec<char>>()
-                        .iter()
-                    {
-                        let mut permutation = self.fqdn.to_string();
-                        permutation.insert(i, *keyboard_char);
-                        result.push(permutation);
-                    }
-                }
-            }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn insertion(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(
+            self.fqdn
+                .chars()
+                .skip(1) // We don't want to insert at the beginning of the domain...
+                .take(self.fqdn.len() - 2) // ...or at the end of the domain.
+                .enumerate()
+                .flat_map(move |(i, c)| {
+                    KEYBOARD_LAYOUTS.iter().filter_map(move |layout| {
+                        layout
+                            .get(&c) // Option<&[char]>
+                            .map(move |keyboard_chars| {
+                                keyboard_chars.chars().map(move |keyboard_char| {
+                                    let mut permutation = self.fqdn.to_string();
+                                    permutation.insert(i, keyboard_char);
+                                    permutation
+                                })
+                            })
+                    })
+                })
+                .flatten(),
+        )
     }
 
     /// Permutation method that selectively removes a character from the domain.
-    pub fn omission(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-
-        for (i, _) in self.fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            // @CLEANUP(jdb): Any way to do this nicely? Just want to avoid
-            //                out of bounds issues.
-            if i == self.fqdn.len() {
-                break;
-            }
-
-            result.push(format!("{}{}", &self.fqdn[..i], &self.fqdn[i + 1..]));
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn omission(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(self.fqdn.chars().enumerate().map(move |(i, _)| {
+            let mut permutation = self.fqdn.to_string();
+            permutation.remove(i);
+            permutation
+        }))
     }
 
     /// Permutation method that repeats characters twice provided they are
     /// alphabetic characters (e.g. `google.com` -> `gooogle.com`).
-    pub fn repetition(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-
-        for (i, c) in self.fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            // @CLEANUP(jdb): Any way to do this nicely? Just want to avoid
-            //                out of bounds issues.
-            if i == self.fqdn.len() {
-                break;
-            }
-
+    pub fn repetition(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(self.fqdn.chars().enumerate().filter_map(move |(i, c)| {
             if c.is_alphabetic() {
-                result.push(format!("{}{}{}", &self.fqdn[..=i], c, &self.fqdn[i + 1..]));
+                Some(format!("{}{}{}", &self.fqdn[..=i], c, &self.fqdn[i + 1..]))
+            } else {
+                None
             }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+        }))
     }
 
     /// Permutation method similar to insertion, except that it replaces a given
     /// character with another character in proximity depending on keyboard layout.
-    pub fn replacement(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-
-        for (i, c) in self.fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            // We do not want to insert in the beginning or in the end of the domain
-            if i == 0 || i == self.fqdn.len() - 1 {
-                continue;
-            }
-
-            for keyboard_layout in KEYBOARD_LAYOUTS.iter() {
-                if keyboard_layout.contains_key(c) {
-                    for keyboard_char in keyboard_layout
-                        .get(c)
-                        .unwrap()
-                        .chars()
-                        .collect::<Vec<char>>()
-                        .iter()
-                    {
-                        result.push(format!(
-                            "{}{}{}",
-                            &self.fqdn[..i],
-                            *keyboard_char,
-                            &self.fqdn[i + 1..]
-                        ));
-                    }
-                }
-            }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn replacement(&self) -> impl Iterator<Item = String> + '_ {
+        Self::filter_domains(
+            self.fqdn
+                .chars()
+                .skip(1) // We don't want to insert at the beginning of the domain...
+                .take(self.fqdn.len() - 2) // ...or at the end of the domain.
+                .enumerate()
+                .flat_map(move |(i, c)| {
+                    KEYBOARD_LAYOUTS.iter().filter_map(move |layout| {
+                        layout.get(&c).map(move |keyboard_chars| {
+                            keyboard_chars.chars().map(move |keyboard_char| {
+                                format!(
+                                    "{}{}{}",
+                                    &self.fqdn[..i],
+                                    keyboard_char,
+                                    &self.fqdn[i + 1..]
+                                )
+                            })
+                        })
+                    })
+                })
+                .flatten(),
+        )
     }
 
-    pub fn subdomain(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-        let fqdn = self.fqdn.chars().collect::<Vec<char>>();
-
-        for (i, c) in fqdn.iter().enumerate() {
-            if i == 0 || i > self.fqdn.len() - 3 {
-                continue;
-            }
-
-            let prev_char = &fqdn[i - 1];
-            let invalid_chars = vec!['-', '.'];
-
-            if !invalid_chars.contains(c) && !invalid_chars.contains(prev_char) {
-                result.push(format!("{}.{}", &self.fqdn[..i], &self.fqdn[i..]));
-            }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn subdomain(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(
+            self.fqdn
+                .chars()
+                .take(self.fqdn.len() - 3)
+                .enumerate()
+                .tuple_windows()
+                .filter_map(move |((_, c1), (i2, c2))| {
+                    if ['-', '.'].iter().all(|x| [c1, c2].contains(x)) {
+                        None
+                    } else {
+                        Some(format!("{}.{}", &self.fqdn[..i2], &self.fqdn[i2..]))
+                    }
+                }),
+        )
     }
 
     /// Permutation method that swaps out characters in the domain (e.g.
     /// `google.com` -> `goolge.com`).
-    pub fn transposition(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-        let fqdn = self.fqdn.chars().collect::<Vec<char>>();
-
-        for (i, c) in fqdn.iter().enumerate() {
-            if i == 0 || i == self.fqdn.len() - 1 {
-                continue;
-            }
-
-            let prev_char = &fqdn[i - 1];
-            if c != prev_char {
-                result.push(format!(
-                    "{}{}{}{}",
-                    &self.fqdn[..i],
-                    &fqdn[i + 1],
-                    c,
-                    &self.fqdn[i + 2..]
-                ));
-            }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn transposition(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(self.fqdn.chars().enumerate().tuple_windows().filter_map(
+            move |((i1, c1), (i2, c2))| {
+                if c1 == c2 {
+                    None
+                } else {
+                    Some(format!(
+                        "{}{}{}{}",
+                        &self.fqdn[..i1],
+                        c2,
+                        c1,
+                        &self.fqdn[i2 + 1..]
+                    ))
+                }
+            },
+        ))
     }
 
     /// Permutation method that swaps vowels for other vowels (e.g.
     /// `google.com` -> `gougle.com`).
-    pub fn vowel_swap(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-
-        for (i, c) in self.fqdn.chars().collect::<Vec<char>>().iter().enumerate() {
-            for vowel in VOWELS.iter() {
-                if VOWELS.contains(c) {
-                    result.push(format!(
-                        "{}{}{}",
-                        &self.fqdn[..i],
-                        *vowel,
-                        &self.fqdn[i + 1..]
-                    ));
-                }
-            }
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn vowel_swap(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(
+            self.fqdn
+                .chars()
+                .enumerate()
+                .filter_map(move |(i, c)| {
+                    if VOWELS.contains(&c) {
+                        Some(VOWELS.iter().filter_map(move |vowel| {
+                            if *vowel == c {
+                                None
+                            } else {
+                                Some(format!(
+                                    "{}{}{}",
+                                    &self.fqdn[..i],
+                                    vowel,
+                                    &self.fqdn[i + 1..]
+                                ))
+                            }
+                        }))
+                    } else {
+                        None
+                    }
+                })
+                .flatten(),
+        )
     }
 
     /// Permutation mode that appends and prepends common keywords to the
@@ -475,36 +407,24 @@ impl<'a> Domain<'a> {
     /// 2. Prepend keyword (e.g. `foo.com` -> `wordfoo.com`)
     /// 3. Append keyword and dash (e.g. `foo.com` -> `foo-word.com`)
     /// 4. Append keyword and dash (e.g. `foo.com` -> `fooword.com`)
-    pub fn keyword(&self) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut result: Vec<String> = vec![];
-
-        for keyword in KEYWORDS.iter() {
-            result.push(format!("{}-{}.{}", &self.domain, keyword, &self.tld));
-
-            result.push(format!("{}{}.{}", &self.domain, keyword, &self.tld));
-
-            result.push(format!("{}-{}.{}", keyword, &self.domain, &self.tld));
-
-            result.push(format!("{}{}.{}", keyword, &self.domain, &self.tld));
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn keyword(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(KEYWORDS.iter().flat_map(move |keyword| {
+            vec![
+                format!("{}-{}.{}", &self.domain, keyword, &self.tld),
+                format!("{}{}.{}", &self.domain, keyword, &self.tld),
+                format!("{}-{}.{}", keyword, &self.domain, &self.tld),
+                format!("{}{}.{}", keyword, &self.domain, &self.tld),
+            ]
+        }))
     }
 
     /// Permutation method that replaces all TLDs as variations of the
     /// root domain passed.
-    pub fn tld(&self) -> Result<impl Iterator<Item = String> + '_> {
-        let mut result: Vec<String> = vec![];
-
-        for tld in TLDS.iter() {
-            result.push(format!("{}.{}", &self.domain, tld));
-        }
-
-        dbg!(&result);
-
-        Domain::filter_domains(Box::new(result.into_iter()))
+    pub fn tld(&self) -> impl Iterator<Item = String> + '_ {
+        Domain::filter_domains(
+            TLDS.iter()
+                .map(move |tld| format!("{}.{}", &self.domain, tld)),
+        )
     }
 
     /// Utility function that filters an iterator of domains that are valid. This
@@ -516,44 +436,19 @@ impl<'a> Domain<'a> {
     ///
     /// 2nd pass - simple regular expression pass to see if the resulting domains
     /// are indeed valid domains.
-    pub fn filter_domains(permutations: Box<dyn Iterator<Item = String>>) -> Result<Box<dyn Iterator<Item = String>>> {
-        let mut punycode_domains: HashSet<String> = HashSet::new();
-
-        // First filter pass for domains that can be punycode decoded
-        for permutation in permutations {
-            // As per punycode documentation, any xn-- needs to be removed
-            let stripped_permutation = permutation.replace("xn--", "");
-
-            let is_decodable = &stripped_permutation
-                .split(".")
-                .all(|part| match punycode::decode(&part) {
-                    Some(_) => true,
-                    None => false,
-                });
-
-            if *is_decodable {
-                punycode_domains.insert(permutation);
-            }
-        }
-
-        let mut result: Vec<String> = vec![];
-
-        // Second filter pass for domains that are valid
-        for domain in punycode_domains {
-            match IDNA_FILTER_REGEX.is_match(&domain) {
-                Ok(is_matched) => {
-                    if is_matched {
-                        result.push(domain);
-                    }
-                }
-                Err(_) => {
-                    dbg!(&domain);
-                }
-            }
-        }
-
-        Ok(Box::new(result.into_iter()))
+    pub fn filter_domains<T>(permutations: T) -> impl Iterator<Item = String>
+    where
+        T: Iterator<Item = String>,
+    {
+        permutations
+            .filter(|x| is_valid_punycode(x) && IDNA_FILTER_REGEX.is_match(x).unwrap_or(false))
     }
+}
+
+fn is_valid_punycode(x: &str) -> bool {
+    x.replace("xn--", "")
+        .split('.')
+        .all(|part| punycode::decode(part).is_some())
 }
 
 #[cfg(test)]
@@ -563,130 +458,113 @@ mod tests {
     #[test]
     fn test_all_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.all();
+        let permutations: Vec<_> = d.all().collect();
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_addition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.addition();
+        let permutations: Vec<_> = dbg!(d.addition().collect());
 
-        assert!(permutations.is_ok());
-        assert_eq!(
-            permutations.unwrap().collect::<Vec<String>>().len(),
-            ASCII_LOWER.len()
-        );
+        assert_eq!(permutations.len(), ASCII_LOWER.len());
     }
 
     #[test]
     fn test_bitsquatting_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.bitsquatting();
+        let permutations: Vec<_> = dbg!(d.bitsquatting().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_homoglyph_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.homoglyph();
+        let permutations: Vec<_> = dbg!(d.homoglyph().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_hyphenation_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.hyphentation();
+        let permutations: Vec<_> = dbg!(d.hyphentation().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_insertion_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.insertion();
+        let permutations: Vec<_> = dbg!(d.insertion().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_omission_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.omission();
+        let permutations: Vec<_> = dbg!(d.omission().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_repetition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.repetition();
+        let permutations: Vec<_> = dbg!(d.repetition().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_replacement_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.replacement();
+        let permutations: Vec<_> = dbg!(d.replacement().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_subdomain_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.subdomain();
+        let permutations: Vec<_> = dbg!(d.subdomain().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_transposition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.transposition();
+        let permutations: Vec<_> = dbg!(d.transposition().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_vowel_swap_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.vowel_swap();
+        let permutations: Vec<_> = dbg!(d.vowel_swap().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_keyword_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.keyword();
+        let permutations: Vec<_> = dbg!(d.keyword().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
     fn test_tld_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations = d.tld();
+        let permutations: Vec<_> = dbg!(d.tld().collect());
 
-        assert!(permutations.is_ok());
-        assert!(permutations.unwrap().collect::<Vec<String>>().len() > 0);
+        assert!(permutations.len() > 0);
     }
 
     #[test]
@@ -710,9 +588,7 @@ mod tests {
         ];
 
         let filtered_domains: Vec<String> =
-            Domain::filter_domains(Box::new(valid_idns.into_iter()))
-                .unwrap()
-                .collect();
+            Domain::filter_domains(valid_idns.into_iter()).collect();
 
         dbg!(&filtered_domains);
 


### PR DESCRIPTION
Hi!

Not sure if you'd be interested in this change but it fit my use case slightly better and thought you may find it useful - feel free to close this if not.

It removes the `Box`ing and fallibility on all the various permutation methods of `Domain` to simplify the API slightly and (hopefully) improve memory usage, since there are no internal vecs, just iterators.

I think some of these methods may actually be slightly slower than before, although I'm not sure how, and the difference is a few microseconds here and there. I have a separate branch with benchmarks which I'll push so you can use them and see for yourself if you like.