### PR TITLE
Rework error-handling library wide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-native-tls"
@@ -2179,22 +2179,22 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2698,9 +2698,10 @@ dependencies = [
 
 [[package]]
 name = "twistrs"
-version = "0.4.2-beta"
+version = "0.4.3"
 dependencies = [
  "addr",
+ "anyhow",
  "async-smtp",
  "criterion",
  "fancy-regex",
@@ -2713,6 +2714,7 @@ dependencies = [
  "phf",
  "punycode",
  "serde 1.0.140",
+ "thiserror",
  "tokio 0.2.25",
  "tokio 1.20.0",
  "whois-rust",
@@ -2722,6 +2724,7 @@ dependencies = [
 name = "twistrs-cli"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "clap 3.2.14",
  "colored",
  "futures",

--- a/examples/twistrs-cli/Cargo.toml
+++ b/examples/twistrs-cli/Cargo.toml
@@ -10,3 +10,4 @@ clap = "3.2.10"
 colored = "1.9.3"
 tokio = { version = "0.2", features = ["full"] }
 futures = { version = "0.3", features = ["thread-pool"] }
+anyhow = "1.0.71"

--- a/examples/twistrs-cli/src/main.rs
+++ b/examples/twistrs-cli/src/main.rs
@@ -5,11 +5,12 @@ use tokio::sync::mpsc;
 use twistrs::enrich::DomainMetadata;
 use twistrs::permutate::Domain;
 
+use anyhow::Result;
 use std::collections::HashSet;
 use std::time::Instant;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let start_time = Instant::now();
 
     let matches = App::new("twistrs-cli")
@@ -20,10 +21,10 @@ async fn main() {
 
     let domain = Domain::new(matches.value_of("domain").unwrap()).unwrap();
 
-    let mut domain_permutations = domain.all().collect::<HashSet<String>>();
+    let mut domain_permutations = domain.all()?.collect::<HashSet<String>>();
     let domain_permutation_count = domain_permutations.len();
 
-    domain_permutations.insert(String::from(&(*domain.fqdn)));
+    domain_permutations.insert(String::from(domain.fqdn));
 
     let (tx, mut rx) = mpsc::channel(5000);
 
@@ -80,4 +81,6 @@ async fn main() {
         "Execution time".bold(),
         start_time.elapsed().as_secs()
     );
+
+    Ok(())
 }

--- a/examples/twistrs-grpc/src/server.rs
+++ b/examples/twistrs-grpc/src/server.rs
@@ -1,3 +1,5 @@
+mod domain_enumeration;
+
 use tokio::sync::mpsc;
 
 use tonic::{transport::Server, Request, Response, Status};
@@ -6,10 +8,7 @@ use twistrs::enrich::DomainMetadata;
 use twistrs::permutate::Domain;
 
 use domain_enumeration::domain_enumeration_server::{DomainEnumeration, DomainEnumerationServer};
-
 use domain_enumeration::{DomainEnumerationResponse, Fqdn, MxCheckResponse};
-
-mod domain_enumeration;
 
 #[derive(Default)]
 pub struct DomainEnumerationService {}
@@ -25,7 +24,7 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendDnsResolutionStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
+        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all().unwrap() {
             let domain_metadata = DomainMetadata::new(permutation.clone());
             let mut tx = tx.clone();
 
@@ -62,7 +61,7 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendMxCheckStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
+        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all().unwrap() {
             let domain_metadata = DomainMetadata::new(permutation.clone());
             let mut tx = tx.clone();
 

--- a/examples/twistrs-ws/src/main.rs
+++ b/examples/twistrs-ws/src/main.rs
@@ -93,8 +93,8 @@ async fn user_message(my_id: usize, msg: Message, users: &Users) {
             eprintln!("initiating dns resolution checks for user: {}", my_id);
 
             let domain = Domain::new(msg).unwrap();
-            let mut domain_permutations = domain.all().collect::<HashSet<String>>();
-            domain_permutations.insert(String::from(&(*domain.fqdn)));
+            let mut domain_permutations = domain.all().unwrap().collect::<HashSet<String>>();
+            domain_permutations.insert(String::from(domain.fqdn));
 
             for v in domain_permutations.into_iter() {
                 let domain_metadata = DomainMetadata::new(v.clone());

--- a/twistrs/Cargo.toml
+++ b/twistrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twistrs"
-version = "0.4.2-beta"
+version = "0.4.3"
 description = "An asynchronous domain name permutation and enumeration library."
 license = "MIT"
 repository = "https://github.com/JuxhinDB/twistrs"
@@ -35,6 +35,8 @@ itertools = "0.9.0"
 serde = { version = "1.0.140", default_features = false, features = ["derive"]}
 maxminddb = { version = "0.15.0", optional = true}
 whois-rust = { version = "1.2.3", optional = true}
+thiserror = "1.0.43"
+anyhow = "1.0.71"
 
 [build-dependencies]
 punycode = "0.4.1"

--- a/twistrs/benches/bench_permute.rs
+++ b/twistrs/benches/bench_permute.rs
@@ -7,7 +7,7 @@ fn bitsquatting(domain: &Domain) {
 }
 
 fn homoglyph(domain: &Domain) {
-    domain.homoglyph().for_each(drop)
+    domain.homoglyph().unwrap().for_each(drop)
 }
 
 fn hyphentation(domain: &Domain) {

--- a/twistrs/build.rs
+++ b/twistrs/build.rs
@@ -127,7 +127,7 @@ fn main() {
     // Write out contents to the final Rust file artifact
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("data.rs");
-    fs::write(&dest_path, dicionary_output).unwrap();
+    fs::write(dest_path, dicionary_output).unwrap();
 }
 
 // The output is wrapped in a Result to allow matching on errors

--- a/twistrs/src/enrich.rs
+++ b/twistrs/src/enrich.rs
@@ -19,9 +19,7 @@
 //!
 //! Note that the enrichment module is independent from the
 //! permutation module and can be used with any given FQDN.
-
 use serde::Serialize;
-use std::fmt;
 use std::net::IpAddr;
 
 #[cfg(feature = "geoip_lookup")]
@@ -38,25 +36,41 @@ use hyper::{Body, Request};
 use tokio::net;
 
 use crate::constants::HTTP_CLIENT;
+use crate::error::Error;
 
 #[cfg(feature = "whois_lookup")]
 use crate::constants::WHOIS;
 
-/// Temporary type-alias over `EnrichmentError`.
-pub type Result<T> = std::result::Result<T, EnrichmentError>;
+#[derive(thiserror::Error, Debug)]
+pub enum EnrichmentError {
+    #[error("error resolving domain name (domain: {domain})")]
+    DnsResolutionError { domain: String },
 
-#[derive(Copy, Clone, Debug)]
-#[deprecated(
-    since = "0.1.0",
-    note = "Prone to be removed in the future, does not currently provide any context."
-)]
-pub struct EnrichmentError;
+    #[cfg(feature = "whois_lookup")]
+    #[error("error resolving domain name (domain: {domain}, error: {error})")]
+    WhoIsLookupError {
+        domain: String,
+        error: whois_rust::WhoIsError,
+    },
 
-impl fmt::Display for EnrichmentError {
-    // @CLEANUP(jdb): Make this something meaningful, if it needs to be
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
+    #[cfg(feature = "smtp_lookup")]
+    #[error("error performing smtp lookup (domain: {domain}, error: {error})")]
+    SmtpLookupError {
+        domain: String,
+        error: anyhow::Error,
+    },
+
+    #[error("error performing http banner lookup (domain: {domain}, error: {error})")]
+    HttpBannerError {
+        domain: String,
+        error: anyhow::Error,
+    },
+
+    #[error("error performing geoip lookup (domain: {domain}, error: {error})")]
+    GeoIpLookupError {
+        domain: String,
+        error: anyhow::Error,
+    },
 }
 
 /// Container to store interesting FQDN metadata
@@ -118,18 +132,20 @@ impl DomainMetadata {
     /// otherwise returns `Err(EnrichmentError)`.
     ///
     /// **N.B**—also host lookups are done over port 80.
-    pub async fn dns_resolvable(&self) -> Result<DomainMetadata> {
-        match net::lookup_host(&format!("{}:80", self.fqdn)[..]).await {
-            Ok(addrs) => Ok(DomainMetadata {
+    pub async fn dns_resolvable(&self) -> Result<DomainMetadata, Error> {
+        Ok(net::lookup_host(&format!("{}:80", self.fqdn)[..])
+            .await
+            .map(|addrs| DomainMetadata {
                 fqdn: self.fqdn.clone(),
                 ips: Some(addrs.map(|addr| addr.ip()).collect()),
                 smtp: None,
                 http_banner: None,
                 geo_ip_lookups: None,
                 who_is_lookup: None,
-            }),
-            Err(_) => Err(EnrichmentError),
-        }
+            })
+            .map_err(|_| EnrichmentError::DnsResolutionError {
+                domain: self.fqdn.clone(),
+            })?)
     }
 
     /// Asynchronous SMTP check. Attempts to establish an SMTP
@@ -141,13 +157,16 @@ impl DomainMetadata {
     /// if the SMTP relay worked, check that
     /// `DomainMetadata.smtp` is `Some(v)`.
     #[cfg(feature = "smtp_lookup")]
-    pub async fn mx_check(&self) -> Result<DomainMetadata> {
+    pub async fn mx_check(&self) -> Result<DomainMetadata, Error> {
         let email = SendableEmail::new(
             Envelope::new(
                 Some("twistrs@example.com".parse().unwrap()),
                 vec!["twistrs@example.com".parse().unwrap()],
             )
-            .unwrap(),
+            .map_err(|e| EnrichmentError::SmtpLookupError {
+                domain: self.fqdn.clone(),
+                error: anyhow::Error::msg(e),
+            })?,
             "Twistrs",
             "And that's how the cookie crumbles\n",
         );
@@ -160,8 +179,11 @@ impl DomainMetadata {
             ClientSecurity::None,
         );
 
-        match smtp.into_transport().connect_and_send(email).await {
-            Ok(response) => Ok(DomainMetadata {
+        let result = smtp
+            .into_transport()
+            .connect_and_send(email)
+            .await
+            .map(|response| DomainMetadata {
                 fqdn: self.fqdn.clone(),
                 ips: None,
                 smtp: Some(SmtpMetadata {
@@ -171,18 +193,18 @@ impl DomainMetadata {
                 http_banner: None,
                 geo_ip_lookups: None,
                 who_is_lookup: None,
-            }),
+            });
 
-            // @CLEANUP(JDB): Currently for most scenarios, the following call with return
-            //                an `std::io::ErrorKind::ConnectionRefused` which is normal.
-            //
-            //                In such a scenario, we still do not want to panic but instead
-            //                move on. Currently lettre::smtp::error::Error does not support
-            //                the `fn kind` function to be able to handle error variants.
-            //
-            //                Try to figure out if there is another way to handle them.
-            Err(_) => Ok(DomainMetadata::new(self.fqdn.clone())),
-        }
+        Ok(match result {
+            Ok(domain_metadata) => Ok(domain_metadata),
+            Err(async_smtp::smtp::error::Error::Timeout(_)) => {
+                Ok(DomainMetadata::new(self.fqdn.clone()))
+            }
+            Err(e) => Err(EnrichmentError::SmtpLookupError {
+                domain: self.fqdn.clone(),
+                error: anyhow::Error::msg(e),
+            }),
+        }?)
     }
 
     /// Asynchronous HTTP Banner fetch. Searches and parses `server` header
@@ -202,35 +224,44 @@ impl DomainMetadata {
     ///     println!("{:?}", domain_metadata.http_banner().await);
     /// }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Currently panics if the HTTP server header value is not parseable.
-    /// For more information please refer to the
-    /// [Hyper implementation](https://docs.rs/hyper/hyper/header/struct.HeaderValue.html#method.to_str).
-    pub async fn http_banner(&self) -> Result<DomainMetadata> {
+    pub async fn http_banner(&self) -> Result<DomainMetadata, Error> {
         // Construst the basic request to be sent out
         let request = Request::builder()
             .method("HEAD")
             .uri(format!("http://{}", &self.fqdn))
-            .header("User-Agent", "github-twistrs-http-banner/1.0")
+            .header("User-Agent", "github-juxhindb-twistrs-http-banner/1.0")
             .body(Body::from("")) // This is annoying
-            .unwrap();
+            .map_err(|e| EnrichmentError::HttpBannerError {
+                domain: self.fqdn.clone(),
+                error: anyhow::Error::msg(e),
+            })?;
 
-        match HTTP_CLIENT.request(request).await {
-            Ok(response) => match response.headers().get("server") {
-                Some(server) => Ok(DomainMetadata {
+        if let Ok(response) = HTTP_CLIENT.request(request).await {
+            if let Some(server_header) = response.headers().get("server") {
+                let server =
+                    server_header
+                        .to_str()
+                        .map_err(|e| EnrichmentError::HttpBannerError {
+                            domain: self.fqdn.clone(),
+                            error: anyhow::Error::msg(e),
+                        })?;
+
+                return Ok(DomainMetadata {
                     fqdn: self.fqdn.clone(),
                     ips: None,
                     smtp: None,
-                    http_banner: Some(String::from(server.to_str().unwrap())),
+                    http_banner: Some(String::from(server)),
                     geo_ip_lookups: None,
                     who_is_lookup: None,
-                }),
-                None => Ok(DomainMetadata::new(self.fqdn.clone())),
-            },
-            Err(_) => Ok(DomainMetadata::new(self.fqdn.clone())),
+                });
+            }
         }
+
+        Err(EnrichmentError::HttpBannerError {
+            domain: self.fqdn.clone(),
+            error: anyhow::Error::msg("unable to extract or parse server header from response"),
+        }
+        .into())
     }
 
     /// Asynchronous cached GeoIP lookup. Interface deviates from the usual enrichment
@@ -255,16 +286,14 @@ impl DomainMetadata {
     /// }
     /// ```
     ///
-    /// ### Panics
-    ///
-    /// Currently assumes that if a City/Country/Continent is found, that the English ("en")
-    /// result is available.
-    ///
     /// ### Features
     ///
     /// This function requires the `geoip_lookup` feature toggled.
     #[cfg(feature = "geoip_lookup")]
-    pub async fn geoip_lookup(&self, geoip: &maxminddb::Reader<Vec<u8>>) -> Result<DomainMetadata> {
+    pub async fn geoip_lookup(
+        &self,
+        geoip: &maxminddb::Reader<Vec<u8>>,
+    ) -> Result<DomainMetadata, Error> {
         let mut result: Vec<(IpAddr, String)> = Vec::new();
 
         match &self.ips {
@@ -278,11 +307,15 @@ impl DomainMetadata {
                                 geoip_string.push_str(
                                     lookup_result
                                         .city
-                                        .unwrap()
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg("could not find city"),
+                                        })?
                                         .names
-                                        .unwrap()
-                                        .get("en")
-                                        .unwrap(),
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg("could not find city names"),
+                                        })?["en"],
                                 );
                             }
 
@@ -294,11 +327,17 @@ impl DomainMetadata {
                                 geoip_string.push_str(
                                     lookup_result
                                         .country
-                                        .unwrap()
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg("could not find country"),
+                                        })?
                                         .names
-                                        .unwrap()
-                                        .get("en")
-                                        .unwrap(),
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg(
+                                                "could not find country names",
+                                            ),
+                                        })?["en"],
                                 );
                             }
 
@@ -310,11 +349,17 @@ impl DomainMetadata {
                                 geoip_string.push_str(
                                     lookup_result
                                         .continent
-                                        .unwrap()
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg("could not find continent"),
+                                        })?
                                         .names
-                                        .unwrap()
-                                        .get("en")
-                                        .unwrap(),
+                                        .ok_or(EnrichmentError::GeoIpLookupError {
+                                            domain: self.fqdn.clone(),
+                                            error: anyhow::Error::msg(
+                                                "could not find continent name",
+                                            ),
+                                        })?["en"],
                                 );
                             }
 
@@ -330,7 +375,7 @@ impl DomainMetadata {
         }
     }
 
-    /// Asyncrhonous WhoIs lookup using cached WhoIs server config. Note that
+    /// Asyncrhonous `WhoIs` lookup using cached WhoIs server config. Note that
     /// the internal lookups are not async and so this should be considered
     /// a heavy/slow call.
     ///
@@ -348,35 +393,28 @@ impl DomainMetadata {
     ///
     /// This function requires the `whois_lookup` feature toggled.
     #[cfg(feature = "whois_lookup")]
-    pub async fn whois_lookup(&self) -> Result<DomainMetadata> {
+    pub async fn whois_lookup(&self) -> Result<DomainMetadata, Error> {
         let mut result = DomainMetadata::new(self.fqdn.clone());
 
-        match WhoIsLookupOptions::from_string(&self.fqdn) {
-            Ok(mut lookup_options) => {
-                lookup_options.timeout = Some(std::time::Duration::from_secs(5)); // Change default timeout from 60s to 5s
-                lookup_options.follow = 1; // Only allow at most one redirect
+        let whois_lookup_options = WhoIsLookupOptions::from_string(&self.fqdn).map_err(|e| {
+            EnrichmentError::WhoIsLookupError {
+                domain: self.fqdn.to_string(),
+                error: e,
+            }
+        })?;
 
-                match WHOIS.lookup(lookup_options) {
-                    Ok(lookup_result) => {
-                        result.who_is_lookup = Some(String::from(
-                            &lookup_result
-                                .split("\r\n")
-                                // The only entries we care about are the ones that start with 3 spaces.
-                                // Ideally the whois_rust library would have parsed this nicely for us.
-                                .filter(|s| s.starts_with("   "))
-                                .collect::<Vec<&str>>()
-                                .join("\n"),
-                        ));
-                    }
-                    Err(e) => {
-                        eprintln!("{}", e)
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!("{}", e)
-            }
-        }
+        result.fqdn = WHOIS
+            .lookup(whois_lookup_options)
+            .map_err(|e| EnrichmentError::WhoIsLookupError {
+                domain: self.fqdn.to_string(),
+                error: e,
+            })?
+            .split("\r\n")
+            // The only entries we care about are the ones that start with 3 spaces.
+            // Ideally the whois_rust library would have parsed this nicely for us.
+            .filter(|s| s.starts_with("   "))
+            .collect::<Vec<&str>>()
+            .join("\n");
 
         Ok(result)
     }
@@ -384,17 +422,12 @@ impl DomainMetadata {
     /// Performs all FQDN enrichment methods on a given FQDN.
     /// This is the only function that returns a `Vec<DomainMetadata>`.
     ///
-    /// **N.B** -- this is currently very slow, and serializes the
-    /// operations rather than running them concurrently. It should
-    /// only be used for testing or debugging purposes.
-    ///
     /// # Panics
     ///
     /// Currently panics if any of the internal enrichment methods returns
     /// an Err.
-    pub async fn all(&self) -> Result<Vec<DomainMetadata>> {
+    pub async fn all(&self) -> Result<Vec<DomainMetadata>, Error> {
         // @CLEANUP(JDB): This should use try_join! in the future instead
-
         #[cfg(feature = "smtp_lookup")]
         let mx_check = self.mx_check();
 

--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -124,4 +124,5 @@ extern crate lazy_static;
 
 pub mod constants;
 pub mod enrich;
+pub mod error;
 pub mod permutate;


### PR DESCRIPTION
Remove deprecated error structs in favour for `thiserror`/`anyhow` variants